### PR TITLE
Formatting and spelling updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@ nav li a {
                 <pre><code class="xml">
 <header>
     <nav>
-    <h1 id="brand">IMA Zebra</h1>
+        <h1 id="brand">IMA Zebra</h1>
         <ul>
             <li><a href="#home">My Home</a></li>
             <li><a href="#diet">My Diet</a></li>
@@ -554,12 +554,12 @@ nav ul {
     <nav>
         <div class="container">
             <h1 id="brand">IMA Zebra</h1>
-                <ul>
-                    <li><a href="#home">My Home</a></li>
-                    <li><a href="#diet">My Diet</a></li>
-                    <li><a href="#pattern">Stripes</a></li>
-                </ul>
-            </div>
+            <ul>
+                <li><a href="#home">My Home</a></li>
+                <li><a href="#diet">My Diet</a></li>
+                <li><a href="#pattern">Stripes</a></li>
+            </ul>
+        </div>
     </nav>
 </header>
 </code></pre>

--- a/index.html
+++ b/index.html
@@ -232,10 +232,10 @@
       margin: 0 auto; /* center content in the viewport */
   }
 </code></pre>
-                <ul>
-                    <li>1. The container will take up 100% of the screen if the width of the viewport is less than 1440px.</li>
-                    <li>2. If the viewport is wider than 1440px, it will reach it's max width, and become centered in the viewport.</li>
-                </ul>
+                <ol>
+                    <li>The container will take up 100% of the screen if the width of the viewport is less than 1440px.</li>
+                    <li>If the viewport is wider than 1440px, it will reach it's max width, and become centered in the viewport.</li>
+                </ol>
             </section>
             <section data-background="#f05b62">
                 <h1 style="color: #fafafa;">HTML5</h1>

--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
                         <br/>
                         <p>Members from Apple, Mozilla, &amp; Opera set out to develop HTML5.</li>
                     <li class="fragment">
-                        <strong class="blue">2008:</strong>First verson of HTML5 published</br>
+                        <strong class="blue">2008:</strong>First version of HTML5 published</br>
                         <p>First draft is written, but changes are still coming. HTML5 is continually evolving.</p>
                     </li>
                     <li class="fragment">
@@ -888,7 +888,7 @@ nav ul {
                 </section>
                 <section>
                     <h2>How to use SVG today</h2>
-                    <p>Use Adobe Illustrator, or other vector program, to create a high quality image.</p>
+                    <p>Use Adobe Illustrator, or another vector program, to create a high quality image.</p>
                     <p>Save it as a .svg file.</p>
                     <p>Save a high res .png image as a fallback.</p>
                 </section>
@@ -1515,7 +1515,7 @@ background-image: linear-gradient(bottom right, red, white);
       <section>
         <h2>How did we get here?</h2>
           <ul>
-            <li>In 2010, Ethan Marcotte coined the tearm in an article on <a href="http://alistapart.com/article/responsive-web-design" target="_blank">A List Apart</a></li>
+            <li>In 2010, Ethan Marcotte coined the term in an article on <a href="http://alistapart.com/article/responsive-web-design" target="_blank">A List Apart</a></li>
             <li>In 2011, he wrote the book on it (literally), called: "Responsive Web Design"</li>
             <li>In 2012, RWD was the #2 trend in web design</li>
             <li>2013 was called "The Year of Responsive Web Design" because it was and still is a cost effective alternative to mobile apps</li>


### PR DESCRIPTION
I was reviewing the slides for GDI Chicago. I'm proposing a few small updates:

- Remove hardcoded numbers and use `<ol>` tag on slide 24

**Slide 24:**
![image](https://cloud.githubusercontent.com/assets/2359538/22049827/a1a61f14-dcfb-11e6-96a2-3b079852953e.png)

- Correct typos on slides 27, 89, 147
- Update whitespace to reflect nesting in code examples on slides 49 and 52

**Slide 49:** 
![image](https://cloud.githubusercontent.com/assets/2359538/22049835/b2e54f34-dcfb-11e6-82cb-d70b18e0c300.png)

**Slide 52:**
![image](https://cloud.githubusercontent.com/assets/2359538/22049845/bc6cc0e6-dcfb-11e6-8454-cba34fedcf39.png)
