### PR TITLE
Fix broken download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,7 @@
                 <p>
                     <strong>Password: </strong></p>
                 <br/>
-                <h3>Download workshop files</h3>
-                <p>Please download workshop files at:<br />
-                <a href="http://girldevelopit.github.io/gdi-featured-intermediate-html-css/workshop-files.zip">http://girldevelopit.github.io/gdi-featured-intermediate-html-css/workshop-files.zip</a></p>
+                <h3>Download workshop files <a href="./workshop-files.zip" download> <strong>here</strong></a></h3>
             </section>
             <section>
                 <h2>Thanks to our host:</h2>


### PR DESCRIPTION
The link to download workshop-files.zip  is broken, here's updated markup to fix the error.